### PR TITLE
Update operation and options for put and delete operation.

### DIFF
--- a/src/Riverline/DynamoDB/AttributeUpdate.php
+++ b/src/Riverline/DynamoDB/AttributeUpdate.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+/**
+ * @class
+ */
+class AttributeUpdate implements \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * The update actions
+     * @var array
+     */
+    private $actions = array();
+    
+    /**
+     * @param string $name
+     * @param \Riverline\DynamoDB\UpdateAction $action
+     */
+    public function setAttribute($name, $action)
+    {
+        $this->actions[$name] = $action;
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->actions[$offset]);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @return null
+     */
+    public function offsetGet($offset)
+    {
+        return (isset($this->actions[$offset])?$this->actions[$offset]:null);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @param $value
+     * @throws Exception\AttributesException
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            throw new Exception\AttributesException('Square bracket syntax isn\'t allowed');
+        }
+
+        $this->setAttribute($offset, $value);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->actions[$offset]);
+    }
+
+    /**
+     * @see \IteratorAggregate
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->actions);
+    }
+}

--- a/src/Riverline/DynamoDB/Context/Delete.php
+++ b/src/Riverline/DynamoDB/Context/Delete.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Riverline\DynamoDB\Context;
+
+class Delete extends Put
+{
+}

--- a/src/Riverline/DynamoDB/Context/Put.php
+++ b/src/Riverline/DynamoDB/Context/Put.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Riverline\DynamoDB\Context;
+
+use \Riverline\DynamoDB\ExpectedCondition;
+
+/**
+ * @class
+ */
+class Put
+{
+    /**
+     * Expected values.
+     * @var array
+     */
+    protected $expected;
+
+    /**
+     * A return constant.
+     * \AmazonDynamoDB::RETURN_NONE or \AmazonDynamoDB::RETURN_ALL_OLD for put and delete operations.
+     * \AmazonDynamoDB::RETURN_NONE, \AmazonDynamoDB::RETURN_ALL_OLD, \AmazonDynamoDB::RETURN_ALL_NEW, \AmazonDynamoDB::RETURN_UPDATED_OLD, \AmazonDynamoDB::RETURN_UPDATED_NEW for update operation.
+     * @var string AmazonDynamoDB return constant. 
+     */
+    protected $returnValues;
+
+    /**
+     * @param \Riverline\DynamoDB\Expected $expected
+     */
+    public function setExpected(\Riverline\DynamoDB\Expected $expected)
+    {
+        $this->expected = $expected;
+
+        return $this;
+    }
+
+    /**
+     * @param string $returnValues AmazonDynamoDB return constant
+     * @return \Riverline\DynamoDB\Context\Put
+     */
+    public function setReturnValues($returnValues)
+    {
+        $this->returnValues = $returnValues;
+
+        return $this;
+    }
+
+    /**
+     * Return the context formated for DynamoDB
+     * @return array
+     */
+    public function getForDynamoDB()
+    {
+        $parameters = array();
+
+        $expected = $this->expected;
+        if (null !== $expected) {
+            $expectedParameters = array();
+            foreach ($expected as $name => $attribute) {
+                $expectedParameters[$name] = $attribute->getForDynamoDB();
+            }
+            $parameters['Expected'] = $expectedParameters;
+        }
+
+        $returnValues = $this->returnValues;
+        if (null !== $returnValues) {
+            $parameters['ReturnValues'] = $returnValues;
+        }
+        
+        return $parameters;
+    }
+}

--- a/src/Riverline/DynamoDB/Context/Update.php
+++ b/src/Riverline/DynamoDB/Context/Update.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Riverline\DynamoDB\Context;
+
+class Update extends Put
+{
+}

--- a/src/Riverline/DynamoDB/Expected.php
+++ b/src/Riverline/DynamoDB/Expected.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+/**
+ * @class
+ */
+class Expected implements \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * The expected attributes
+     * @var array
+     */
+    private $attributes = array();
+
+    /**
+     * @param string $name
+     * @param \Riverline\DynamoDB\ExpectedAttribute|mixed $value
+     * @param null|string $type
+     */
+    public function setAttribute($name, $value, $type = null)
+    {
+        if ($value instanceof ExpectedAttribute) {
+            $this->attributes[$name] = $value;
+        } else {
+            $this->attributes[$name] = new ExpectedAttribute($value, $type);
+        }
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @return bool
+     */
+    public function offsetExists($offset)
+    {
+        return isset($this->attributes[$offset]);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @return null
+     */
+    public function offsetGet($offset)
+    {
+        return (isset($this->attributes[$offset])?$this->attributes[$offset]:null);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     * @param $value
+     * @throws Exception\AttributesException
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            throw new Exception\AttributesException('Square bracket syntax isn\'t allowed');
+        }
+
+        $this->setAttribute($offset, $value);
+    }
+
+    /**
+     * @see \ArrayAccess
+     * @param $offset
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->attributes[$offset]);
+    }
+
+    /**
+     * @see \IteratorAggregate
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->attributes);
+    }
+}

--- a/src/Riverline/DynamoDB/ExpectedAttribute.php
+++ b/src/Riverline/DynamoDB/ExpectedAttribute.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+use Riverline\DynamoDB\Attribute;
+
+/**
+ * @class
+ */
+class ExpectedAttribute
+{
+    /**
+     * Whether expected attribute exists or not
+     * @var boolean
+     */
+    protected $exists;
+
+    /**
+     * The expected attribute value
+     * @var \Riverline\DynamoDB\Attribute $value
+     */
+    protected $value;
+
+    /**
+     * @param boolean|\Riverline\DynamoDB\Attribute|mixed|null $value
+     * @param string|null $type
+     */
+    public function __construct($value = null, $type = null)
+    {
+        $this->exists = null;
+        $this->value = null;
+        
+        if (is_bool($value)) {
+            $this->exists = $value;
+        } else if ($value instanceof Attribute) {
+            $this->value = $value;
+        } else {
+            $this->value = new Attribute($value, $type);
+        }
+    }
+
+    /**
+     * Return whether expected attribute exists or not
+     * @return boolean
+     */
+    public function getExists()
+    {
+        return $this->exists;
+    }
+
+    /**
+     * Return the expected attribute value
+     * @return \Riverline\DynamoDB\Attribute $value
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Return the condition formated for DynamoDB
+     * @return array
+     */
+    public function getForDynamoDB()
+    {
+        $exists = $this->getExists();
+        $value = $this->getValue();
+
+        $condition = array();
+        if (isset($exists)) {
+           $condition['Exists'] = $exists;
+        }
+        if (isset($value)) {
+            $condition['Value'] = $value->getForDynamoDB();
+        }
+
+        return $condition;
+    }
+}

--- a/src/Riverline/DynamoDB/UpdateAction.php
+++ b/src/Riverline/DynamoDB/UpdateAction.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+use Riverline\DynamoDB\Attribute;
+
+/**
+ * @class
+ */
+class UpdateAction
+{
+    /**
+     * The update action
+     * @var string. \AmazonDynamoDB::ACTION_ADD, \AmazonDynamoDB::ACTION_DELETE or \AmazonDynamoDB::ACTION_PUT.
+     */
+    protected $action;
+
+    /**
+     * The expected attribute value
+     * @var \Riverline\DynamoDB\Attribute $value
+     */
+    protected $value;
+
+    /**
+     * @param string $action
+     * @param boolean|\Riverline\DynamoDB\Attribute|mixed|null $value
+     * @param string|null $type
+     */
+    public function __construct($action, $value = null, $type = null)
+    {
+        $this->action = $action;
+        $this->value = null;
+        
+        if (null === $value) {
+            $this->value = null;
+        } else if ($value instanceof Attribute) {
+            $this->value = $value;
+        } else {
+            $this->value = new Attribute($value, $type);
+        }
+    }
+
+    /**
+     * Return the update action
+     * @return string
+     */
+    public function getAction()
+    {
+        return $this->action;
+    }
+
+    /**
+     * Return the expected attribute value
+     * @return \Riverline\DynamoDB\Attribute $value
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Return the condition formated for DynamoDB
+     * @return array
+     */
+    public function getForDynamoDB()
+    {
+        $action = $this->getAction();
+        $value = $this->getValue();
+
+        $parameters['Action'] = $action;
+        if (isset($value)) {
+            $parameters['Value'] = $value->getForDynamoDB();
+        }
+
+        return $parameters;
+    }
+}

--- a/tests/Riverline/DynamoDB/AttributeUpdateTest.php
+++ b/tests/Riverline/DynamoDB/AttributeUpdateTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+class AttributeUpdateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWriteAttribute()
+    {
+        $attributeUpdate = new AttributeUpdate();
+
+        $attributeUpdate['name'] = new UpdateAction(\AmazonDynamoDB::ACTION_PUT, 'new name');
+        $this->assertEquals(\AmazonDynamoDB::ACTION_PUT, $attributeUpdate['name']->getAction());
+        $this->assertEquals('new name', $attributeUpdate['name']->getValue()->getValue());
+
+        $attributeUpdate['numbers'] = new UpdateAction(\AmazonDynamoDB::ACTION_ADD, array(10, 11));
+        $this->assertEquals(\AmazonDynamoDB::ACTION_ADD, $attributeUpdate['numbers']->getAction());
+        $this->assertEquals(array(10, 11), $attributeUpdate['numbers']->getValue()->getValue());
+    }
+
+}

--- a/tests/Riverline/DynamoDB/ExpectedAttributeTest.php
+++ b/tests/Riverline/DynamoDB/ExpectedAttributeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+class ExpectedAttributeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNewWithValue()
+    {
+        $expectedAttribute = new ExpectedAttribute('Expected Value');
+
+        $this->assertNull($expectedAttribute->getExists());
+        $this->assertEquals('Expected Value', $expectedAttribute->getValue()->getValue());
+
+        return $expectedAttribute;
+    }
+
+    /**
+     * @depends testNewWithValue
+     */
+    public function testGetForDynamoDBWithValue(ExpectedAttribute $expectedAttribute)
+    {
+        $condition = $expectedAttribute->getForDynamoDB();
+        $this->assertArrayNotHasKey('Exists', $condition);
+        $this->assertEquals(array('S' => 'Expected Value'), $condition['Value']);
+    }
+
+    public function testNewWithExists()
+    {
+        $expectedAttribute = new ExpectedAttribute(false);
+
+        $this->assertEquals(false, $expectedAttribute->getExists());
+        $this->assertNull($expectedAttribute->getValue());
+
+        return $expectedAttribute;
+    }
+
+    /**
+     * @depends testNewWithExists
+     */
+    public function testGetForDynamoDBWithExists(ExpectedAttribute $expectedAttribute)
+    {
+        $condition = $expectedAttribute->getForDynamoDB(); 
+        $this->assertEquals(false, $condition['Exists']);
+        $this->assertArrayNotHasKey('Value', $condition);
+    }
+}

--- a/tests/Riverline/DynamoDB/ExpectedTest.php
+++ b/tests/Riverline/DynamoDB/ExpectedTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+class ExpectedTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWriteAttribute()
+    {
+        $expected = new Expected();
+
+        $expected['name'] = new ExpectedAttribute('expected name');
+        $this->assertEquals('expected name', $expected['name']->getValue()->getValue());
+
+        $expected['numbers'] = new ExpectedAttribute(false);
+        $this->assertEquals(false, $expected['numbers']->getExists());
+    }
+
+}

--- a/tests/Riverline/DynamoDB/UpdateActionTest.php
+++ b/tests/Riverline/DynamoDB/UpdateActionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Riverline\DynamoDB;
+
+class UpdateActionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNew()
+    {
+        $action = new UpdateAction(\AmazonDynamoDB::ACTION_ADD, 10);
+
+        $this->assertEquals(\AmazonDynamoDB::ACTION_ADD, $action->getAction());
+        $this->assertEquals(10, $action->getValue()->getValue());
+
+        return $action;
+    }
+
+    /**
+     * @depends testNew
+     */
+    public function testGetForDynamoDB(UpdateAction $action)
+    {
+        $parameters = $action->getForDynamoDB();
+        $this->assertEquals(\AmazonDynamoDB::ACTION_ADD, $parameters['Action']);
+        $this->assertEquals(array('N' => '10'), $parameters['Value']);
+    }
+}


### PR DESCRIPTION
I made the following additions to riverline-dynamodb.
- update operation.
- options for put and delete operation.
- put, delete and update method return attribute array (when ReturnValues is not NONE).

Would you please review?
