### PR TITLE
Fix population of arrays of strings and arrays of numbers.

### DIFF
--- a/src/Riverline/DynamoDB/Attribute.php
+++ b/src/Riverline/DynamoDB/Attribute.php
@@ -39,11 +39,13 @@ class Attribute implements \IteratorAggregate
                 $value = $value+0;
                 break;
             case \AmazonDynamoDB::TYPE_ARRAY_OF_STRINGS:
-                $value = array_map(function ($value) { return strval($value);}, (array)$value);
+                $value = (array) $value;
+                $value = array_map(function ($value) { return strval($value);}, $value['SS']);
                 sort($value);
                 break;
             case \AmazonDynamoDB::TYPE_ARRAY_OF_NUMBERS:
-                $value = array_map(function ($value) { return $value+0;}, (array)$value);
+                $value = (array) $value;
+                $value = array_map(function ($value) { return $value+0;}, $value['NS']);
                 sort($value);
                 break;
             default:

--- a/src/Riverline/DynamoDB/Attribute.php
+++ b/src/Riverline/DynamoDB/Attribute.php
@@ -40,12 +40,14 @@ class Attribute implements \IteratorAggregate
                 break;
             case \AmazonDynamoDB::TYPE_ARRAY_OF_STRINGS:
                 $value = (array) $value;
-                $value = array_map(function ($value) { return strval($value);}, $value['SS']);
+                $value = isset($value['SS']) ? $value['SS'] : $value;
+                $value = array_map(function ($value) { return strval($value);}, $value);
                 sort($value);
                 break;
             case \AmazonDynamoDB::TYPE_ARRAY_OF_NUMBERS:
                 $value = (array) $value;
-                $value = array_map(function ($value) { return $value+0;}, $value['NS']);
+                $value = isset($value['NS']) ? $value['NS'] : $value;
+                $value = array_map(function ($value) { return $value+0;}, $value);
                 sort($value);
                 break;
             default:

--- a/src/Riverline/DynamoDB/Item.php
+++ b/src/Riverline/DynamoDB/Item.php
@@ -37,6 +37,15 @@ class Item implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Return the Item attributes
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
      * @param string $name
      * @param \Riverline\DynamoDB\Attribute|mixed $value
      * @param null|string $type

--- a/src/Riverline/DynamoDB/Item.php
+++ b/src/Riverline/DynamoDB/Item.php
@@ -46,6 +46,17 @@ class Item implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
+     * Set the attributes for the Item.
+     * @param  array  $attributes
+     */
+    public function setAttributes(array $attributes)
+    {
+        foreach ($attributes as $name => $value) {
+            $this->setAttribute($name, $value);
+        }
+    }
+
+    /**
      * @param string $name
      * @param \Riverline\DynamoDB\Attribute|mixed $value
      * @param null|string $type


### PR DESCRIPTION
This fixes a bug in the population of items containing arrays of strings and array of numbers. The actual data returned from DynamoDB on these types of fields looks something like this:

```
array(
     'SS' => array(
          'foo', 'bar',
     )
)
```
