### PR TITLE
Fix the way to count batch get/write items.

### DIFF
--- a/src/Riverline/DynamoDB/Connection.php
+++ b/src/Riverline/DynamoDB/Connection.php
@@ -369,7 +369,7 @@ class Connection
      */
     public function batchGet(Context\BatchGet $context)
     {
-        if (0 === count($context)) {
+        if (0 === $context->count()) {
             throw new Exception\AttributesException("Context doesn't contain any key to get");
         }
 
@@ -418,7 +418,7 @@ class Connection
      */
     public function batchWrite(Context\BatchWrite $context)
     {
-        if (0 === count($context)) {
+        if (0 === $context->count()) {
             throw new Exception\AttributesException("Context doesn't contain anything to write");
         }
 


### PR DESCRIPTION
To count the content of batch get/write context, I think 
"$context->count()" is more suitable than "count($context)".

I don't know whether this is intentioal or not..
